### PR TITLE
Remove invalid option causing errant setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ You can use the following environment variables for connecting to another databa
  - `-e MEDIAWIKI_DB_USER=...` (defaults to `root` or `postgres` based on db type being `mysql`, or `postgres` respsectively)
  - `-e MEDIAWIKI_DB_PASSWORD=...` (defaults to the password of the linked database container)
  - `-e MEDIAWIKI_DB_NAME=...` (defaults to `mediawiki`)
- - `-e MEDIAWIKI_DB_SCHEMA`... (defaults to `mediawiki`, applies only to when using postgres)
 
 If the `MEDIAWIKI_DB_NAME` specified does not already exist on the provided MySQL
 server, it will be created automatically upon container startup, provided

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -183,7 +183,6 @@ if [ ! -e "LocalSettings.php" -a ! -z "$MEDIAWIKI_SITE_SERVER" ]; then
 	php maintenance/install.php \
 		--confpath /var/www/html \
 		--dbname "$MEDIAWIKI_DB_NAME" \
-		--dbschema "$MEDIAWIKI_DB_SCHEMA" \
 		--dbport "$MEDIAWIKI_DB_PORT" \
 		--dbserver "$MEDIAWIKI_DB_HOST" \
 		--dbtype "$MEDIAWIKI_DB_TYPE" \


### PR DESCRIPTION
The `--dbschema` option is not present in mediawiki 1.23. Having this present causes the dbschema to be used as the site name, and the site name to be used as the administrator.