### PR TITLE
Upgrade to 1.27.3 and resolve build/run issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Benjamin Hutchins <ben@hutchins.co>
 
 # Waiting in antiticipation for built-time arguments
 # https://github.com/docker/docker/issues/14634
-ENV MEDIAWIKI_VERSION 1.25.3
+ENV MEDIAWIKI_VERSION 1.26.0
 
 # Add EXPOSE 443 because the php:apache only has EXPOSE 80
 EXPOSE 80 443
@@ -20,6 +20,7 @@ RUN set -x; \
         libzip-dev \
         imagemagick \
         netcat \
+        git \
     && ln -fs /usr/lib/x86_64-linux-gnu/libzip.so /usr/lib/ \
     && docker-php-ext-install intl mysqli zip mbstring opcache fileinfo \
     && apt-get purge -y --auto-remove g++ libicu-dev libzip-dev \
@@ -44,7 +45,13 @@ RUN MW_VER_MAJOR_PLUS_MINOR=$(php -r '$parts=explode(".", $_ENV["MEDIAWIKI_VERSI
     && curl -fSL "${MEDIAWIKI_DOWNLOAD_URL}.sig" -o mediawiki.tar.gz.sig \
     && gpg --verify mediawiki.tar.gz.sig \
     && tar -xf mediawiki.tar.gz -C /usr/src/mediawiki --strip-components=1 \
-    && rm -f mediawiki.tar.gz mediawiki.tar.gz.sig
+    && rm -f mediawiki.tar.gz mediawiki.tar.gz.sig \
+    && cd /usr/src/mediawiki \
+    && rm -r extensions \
+    # All extensions
+    && git clone https://gerrit.wikimedia.org/r/p/mediawiki/extensions extensions \
+    && cd extensions \
+    && git submodule update --init VisualEditor
 
 COPY php.ini /usr/local/etc/php/conf.d/mediawiki.ini
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN set -x; \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives/* \
     && a2enmod rewrite \
+    && a2enmod proxy \
+    && a2enmod proxy_http \
     # Remove the default Debian index page.
     && rm /var/www/html/index.html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM debian:sid
 MAINTAINER Gabriel Wicke <gwicke@wikimedia.org>
 
-# Waiting in antiticipation for built-time arguments
-# https://github.com/docker/docker/issues/14634
-ENV MEDIAWIKI_VERSION wmf/1.27.0-wmf.9
+ENV MEDIAWIKI_VERSION 1.27.3
 
 # XXX: Consider switching to nginx.
 RUN set -x; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
+# TODO: Switch to debian sid
+
 FROM php:5.6-apache
-MAINTAINER Benjamin Hutchins <ben@hutchins.co>
+MAINTAINER Gabriel Wicke <gwicke@wikimedia.org>
 
 # Waiting in antiticipation for built-time arguments
 # https://github.com/docker/docker/issues/14634
-ENV MEDIAWIKI_VERSION 1.26.0
+ENV MEDIAWIKI_VERSION wmf/1.27.0-wmf.9
 
 # Add EXPOSE 443 because the php:apache only has EXPOSE 80
 EXPOSE 80 443
@@ -24,34 +26,29 @@ RUN set -x; \
     && ln -fs /usr/lib/x86_64-linux-gnu/libzip.so /usr/lib/ \
     && docker-php-ext-install intl mysqli zip mbstring opcache fileinfo \
     && apt-get purge -y --auto-remove g++ libicu-dev libzip-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/cache/apt/archives/* \
+    && a2enmod rewrite
 
-RUN a2enmod rewrite
 
-# https://www.mediawiki.org/keys/keys.txt
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \
-    441276E9CCD15F44F6D97D18C119E1A64D70938E \
-    41B2ABE817ADD3E52BDA946F72BC1C5D23107F8A \
-    162432D9E81C1C618B301EECEE1F663462D84F01 \
-    1D98867E82982C8FE0ABC25F9B69B3109D3BB7B0 \
-    3CEF8262806D3F0B6BA1DBDD7956EE477F901A30 \
-    280DB7845A1DCAC92BB5A00A946B02565DC00AA7
-
-RUN MW_VER_MAJOR_PLUS_MINOR=$(php -r '$parts=explode(".", $_ENV["MEDIAWIKI_VERSION"], 3); echo "{$parts[0]}.{$parts[1]}";'); \
-    MEDIAWIKI_DOWNLOAD_URL="https://releases.wikimedia.org/mediawiki/$MW_VER_MAJOR_PLUS_MINOR/mediawiki-$MEDIAWIKI_VERSION.tar.gz"; \
-    set -x; \
-    mkdir -p /usr/src/mediawiki \
-    && curl -fSL "$MEDIAWIKI_DOWNLOAD_URL" -o mediawiki.tar.gz \
-    && curl -fSL "${MEDIAWIKI_DOWNLOAD_URL}.sig" -o mediawiki.tar.gz.sig \
-    && gpg --verify mediawiki.tar.gz.sig \
-    && tar -xf mediawiki.tar.gz -C /usr/src/mediawiki --strip-components=1 \
-    && rm -f mediawiki.tar.gz mediawiki.tar.gz.sig \
+# MediaWiki setup
+RUN set -x; \
+    mkdir -p /usr/src \
+    && git clone \
+        --depth 1 \
+        -b $MEDIAWIKI_VERSION \
+        https://gerrit.wikimedia.org/r/p/mediawiki/core.git \
+        /usr/src/mediawiki \
     && cd /usr/src/mediawiki \
-    && rm -r extensions \
-    # All extensions
-    && git clone https://gerrit.wikimedia.org/r/p/mediawiki/extensions extensions \
+    && git submodule update --init skins \
+    && git submodule update --init vendor \
     && cd extensions \
-    && git submodule update --init VisualEditor
+    # VisualEditor
+    # TODO: make submodules shallow clones?
+    && git submodule update --init VisualEditor \
+    && cd VisualEditor \
+    && git checkout $MEDIAWIKI_VERSION \
+    && git submodule update --init
 
 COPY php.ini /usr/local/etc/php/conf.d/mediawiki.ini
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN set -x; \
         libicu-dev \
         libzip-dev \
         imagemagick \
+        netcat \
     && ln -fs /usr/lib/x86_64-linux-gnu/libzip.so /usr/lib/ \
     && docker-php-ext-install intl mysqli zip mbstring opcache fileinfo \
     && apt-get purge -y --auto-remove g++ libicu-dev libzip-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Benjamin Hutchins <ben@hutchins.co>
 
 # Waiting in antiticipation for built-time arguments
 # https://github.com/docker/docker/issues/14634
-ENV MEDIAWIKI_VERSION 1.25.2
+ENV MEDIAWIKI_VERSION 1.25.3
 
 # Add EXPOSE 443 because the php:apache only has EXPOSE 80
 EXPOSE 80 443

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ others.
 
 # How to use this image
 
-    docker run --name some-mediawiki --link some-mysql:mysql -v /local/data/path:/data:rw -d benhutchins/mediawiki
+    docker run --name some-mediawiki --link some-mysql:mysql -v /local/data/path:/data:rw -d wikimedia/mediawiki
 
 Partial explanation of arguments:
 
@@ -33,26 +33,19 @@ As mentioned, this will generate the `LocalSettings.php` file that is required b
 
 ## Choosing MediaWiki version
 
-You can use one of the built containers using that version:
+We currently track latest MediaWiki production branches, as run on
+wikipedia.org.
 
- - `benhutchins/mediawiki:1.23` (uses `1.23.10`, official Long Term Support by [MediaWiki](https://www.mediawiki.org/wiki/MediaWiki))
- - `benhutchins/mediawiki:1.23-postgres` (currently uses `1.23.10`, and installs the `postgres` php module)
- - `benhutchins/mediawiki:1.24` (uses `1.24.3`)
- - `benhutchins/mediawiki:1.25` (uses `1.25.2`)
- - `benhutchins/mediawiki:latest` (currently uses `1.25.2`)
- - `benhutchins/mediawiki:postgres` (currently uses `1.25.2`, and installs the `postgres` php module)
+ - `wikimedia/mediawiki:latest` (currently uses `1.27-wmf9`)
 
 To use one of these pre-built containers, simply specify the tag as part of the `docker run` command:
 
-    docker run --name some-mediawiki --link some-postgres:postgres -v /local/data/path:/data:rw -d benhutchins/mediawiki:postgres
+    docker run --name some-mediawiki --link mysql -v /local/data/path:/data:rw -d wikimedia/mediawiki
 
 ## Docker Compose
 
-To run with [Docker Compose](https://docs.docker.com/compose/install/), you'll need to clone this repository and run:
-
-    docker-compose up
-
-**Note** You'll likely want to uncomment the `docker-compose.yml` file's `volume` lines.
+See https://github.com/gwicke/mediawiki-containers for a fully-featured docker
+compose setup with VisualEditor & other services.
 
 ## Configure Database
 
@@ -62,7 +55,7 @@ The example above uses `--link` to connect the MediaWiki container with a runnin
 
 You can use Postgres instead of MySQL as your database server using the `:postgres` tag:
 
-    docker run --name some-mediawiki --link some-postgres:postgres -v /local/data/path:/data:rw -d benhutchins/mediawiki:postgres
+    docker run --name some-mediawiki --link some-postgres:postgres -v /local/data/path:/data:rw -d wikimedia/mediawiki:postgres
 
 ### Using Database Server
 
@@ -89,7 +82,7 @@ To use with an external database server, use `MEDIAWIKI_DB_HOST` (along with
         -e MEDIAWIKI_DB_PORT=3306 \
         -e MEDIAWIKI_DB_USER=app \
         -e MEDIAWIKI_DB_PASSWORD=secure \
-        benhutchins/mediawiki
+        wikimedia/mediawiki
 
 ## Shared Volume
 
@@ -105,7 +98,7 @@ Additionally if a `composer.lock` **and** a `composer.json` are detected, the co
 
 If you'd like to be able to access the instance from the host without the container's IP, standard port mappings can be used using the `-p` or `-P` argument when running `docker run`. See [docs.docker.com](https://docs.docker.com/reference/run/#expose-incoming-ports) for more help.
 
-    docker run --name some-mediawiki --link some-mysql:mysql -p 8080:80 -v /local/data/dir:data:rw -d benhutchins/mediawiki
+    docker run --name some-mediawiki --link some-mysql:mysql -p 8080:80 -v /local/data/dir:data:rw -d wikimedia/mediawiki
 
 Then, access it via `http://localhost:8080` or `http://host-ip:8080` in a browser.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ As mentioned, this will generate the `LocalSettings.php` file that is required b
 We currently track latest MediaWiki production branches, as run on
 wikipedia.org.
 
- - `wikimedia/mediawiki:latest` (currently uses `1.27-wmf9`)
+ - `wikimedia/mediawiki:latest` (currently uses `1.27.3`)
 
 To use one of these pre-built containers, simply specify the tag as part of the `docker run` command:
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ To run with [Docker Compose](https://docs.docker.com/compose/install/), you'll n
 
     docker-compose up
 
-Currently the `docker-compose.yml` is configured to run against `Dockerfile`, which means that it will install MediaWiki version `1.25.2`.
-
 **Note** You'll likely want to uncomment the `docker-compose.yml` file's `volume` lines.
 
 ## Configure Database

--- a/apache/mediawiki.conf
+++ b/apache/mediawiki.conf
@@ -18,6 +18,10 @@ LimitRequestBody 220200960
   </VirtualHost>
 </IfModule>
 
+# Expose REST API at /api/rest_v1/
+ProxyPassInterpolateEnv On
+ProxyPass /api/rest_v1/ ${MEDIAWIKI_RESTBASE_URL}/ interpolate
+
 <Directory /var/www/html>
   # Use of .htaccess files exposes a lot of security risk,
   # disable them and put all the necessary configuration here instead.

--- a/apache/mediawiki.conf
+++ b/apache/mediawiki.conf
@@ -19,8 +19,9 @@ LimitRequestBody 220200960
 </IfModule>
 
 # Expose REST API at /api/rest_v1/
-ProxyPassInterpolateEnv On
-ProxyPass /api/rest_v1/ ${MEDIAWIKI_RESTBASE_URL}/ interpolate
+RewriteEngine On
+RewriteCond ${MEDIAWIKI_RESTBASE_URL} "!^restbase-is-not-specified$"
+RewriteRule "^/api/rest_v1/(.*)$"  "${MEDIAWIKI_RESTBASE_URL}/$1"  [P]
 
 <Directory /var/www/html>
   # Use of .htaccess files exposes a lot of security risk,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -115,7 +115,7 @@ EOPHP
 
 cd /var/www/html
 # FIXME: Keep php files out of the doc root.
-ln -s /usr/src/mediawiki/* .
+ln -sf /usr/src/mediawiki/* .
 
 : ${MEDIAWIKI_SHARED:=/data}
 if [ -d "$MEDIAWIKI_SHARED" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,6 +29,10 @@ if [ -z "$MEDIAWIKI_DB_HOST" ]; then
 	fi
 fi
 
+if [ -z "$MEDIAWIKI_RESTBASE_URL" ]; then
+	export MEDIAWIKI_RESTBASE_URL=restbase-is-not-specified
+fi
+
 if [ -z "$MEDIAWIKI_DB_USER" ]; then
 	if [ "$MEDIAWIKI_DB_TYPE" = "mysql" ]; then
 		echo >&2 'info: missing MEDIAWIKI_DB_USER environment variable, defaulting to "root"'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -204,14 +204,16 @@ if [ ! -e "LocalSettings.php" -a ! -z "$MEDIAWIKI_SITE_SERVER" ]; then
 		"$MEDIAWIKI_SITE_NAME" \
 		"$MEDIAWIKI_ADMIN_USER"
 
+
 		# If we have a mounted share volume, move the LocalSettings.php to it
 		# so it can be restored if this container needs to be reinitiated
 		if [ -d "$MEDIAWIKI_SHARED" ]; then
-			# Append inclusion of /data/CustomSettings.php
-			if [ -e "$MEDIAWIKI_SHARED/CustomSettings.php" ]; then
-				chown www-data: "$MEDIAWIKI_SHARED/CustomSettings.php"
-				echo "include('$MEDIAWIKI_SHARED/CustomSettings.php');" >> LocalSettings.php
-			fi
+            # Append inclusion of /data/CustomSettings.php
+            echo "@include('$MEDIAWIKI_SHARED/CustomSettings.php');" >> LocalSettings.php
+
+            if [ -e "$MEDIAWIKI_SHARED/CustomSettings.php" ]; then
+                chown www-data: "$MEDIAWIKI_SHARED/CustomSettings.php"
+            fi
 
 			# Move generated LocalSettings.php to share volume
 			mv LocalSettings.php "$MEDIAWIKI_SHARED/LocalSettings.php"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -84,6 +84,12 @@ if [ -z "$MEDIAWIKI_DB_PORT" ]; then
 	fi
 fi
 
+# Wait for the DB to come up
+while [ `/bin/nc $MEDIAWIKI_DB_HOST $MEDIAWIKI_DB_PORT < /dev/null; echo $?` != 0 ]; do
+    echo "Waiting for database to come up at $MEDIAWIKI_DB_HOST:$MEDIAWIKI_DB_PORT..."
+    sleep 1
+done
+
 export MEDIAWIKI_DB_TYPE MEDIAWIKI_DB_HOST MEDIAWIKI_DB_USER MEDIAWIKI_DB_PASSWORD MEDIAWIKI_DB_NAME
 
 TERM=dumb php -- <<'EOPHP'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -121,13 +121,14 @@ ln -sf /usr/src/mediawiki/* .
 if [ -d "$MEDIAWIKI_SHARED" ]; then
 	# If there is no LocalSettings.php but we have one under the shared
 	# directory, symlink it
-	if [ -e "$MEDIAWIKI_SHARED/LocalSettings.php" -a ! -e LocalSettings.php ]; then
+	if [ -e "$MEDIAWIKI_SHARED/LocalSettings.php" ]; then
+    rm -f LocalSettings.php
 		ln -s "$MEDIAWIKI_SHARED/LocalSettings.php" LocalSettings.php
 	fi
 
 	# If the images directory only contains a README, then link it to
 	# $MEDIAWIKI_SHARED/images, creating the shared directory if necessary
-	if [ "$(ls images)" = "README" -a ! -L images ]; then
+	if [ "$(ls images)" = "README" ]; then
 		rm -fr images
 		mkdir -p "$MEDIAWIKI_SHARED/images"
 		ln -s "$MEDIAWIKI_SHARED/images" images
@@ -135,7 +136,7 @@ if [ -d "$MEDIAWIKI_SHARED" ]; then
 
 	# If an extensions folder exists inside the shared directory, as long as
 	# /var/www/html/extensions is not already a symbolic link, then replace it
-	if [ -d "$MEDIAWIKI_SHARED/extensions" -a ! -h /var/www/html/extensions ]; then
+	if [ -d "$MEDIAWIKI_SHARED/extensions" ]; then
 		echo >&2 "Found 'extensions' folder in data volume, creating symbolic link."
 		rm -rf /var/www/html/extensions
 		ln -s "$MEDIAWIKI_SHARED/extensions" /var/www/html/extensions
@@ -143,7 +144,7 @@ if [ -d "$MEDIAWIKI_SHARED" ]; then
 
 	# If a skins folder exists inside the shared directory, as long as
 	# /var/www/html/skins is not already a symbolic link, then replace it
-	if [ -d "$MEDIAWIKI_SHARED/skins" -a ! -h /var/www/html/skins ]; then
+	if [ -d "$MEDIAWIKI_SHARED/skins" ]; then
 		echo >&2 "Found 'skins' folder in data volume, creating symbolic link."
 		rm -rf /var/www/html/skins
 		ln -s "$MEDIAWIKI_SHARED/skins" /var/www/html/skins
@@ -151,7 +152,7 @@ if [ -d "$MEDIAWIKI_SHARED" ]; then
 
 	# If a vendor folder exists inside the shared directory, as long as
 	# /var/www/html/vendor is not already a symbolic link, then replace it
-	if [ -d "$MEDIAWIKI_SHARED/vendor" -a ! -h /var/www/html/vendor ]; then
+	if [ -d "$MEDIAWIKI_SHARED/vendor" ]; then
 		echo >&2 "Found 'vendor' folder in data volume, creating symbolic link."
 		rm -rf /var/www/html/vendor
 		ln -s "$MEDIAWIKI_SHARED/vendor" /var/www/html/vendor


### PR DESCRIPTION
This line is sitting on master right now:

```
# Waiting in antiticipation for built-time arguments
# https://github.com/docker/docker/issues/14634
ENV MEDIAWIKI_VERSION wmf/1.27.0-wmf.9
```

This issue is closed, and so I have bumped up the version to 1.27.3.
`1.23` is reaching end of life this month and `1.27` is LTS.
I have also changed the mediawiki downloading method to that seen on other branches, since this is a minor release and not a bleeding edge version.

On rebuilding, you will encounter an issue with `debian:sid`. Sid is always the unstable branch. I have switched it to `debian:jessie`, which appears to be what this was actually working with previously. I also tested it with the `php` image and dependencies seen on other branches and it works fine, but I'm leaving it because I'm not sure why `debian` is used (because master is bleeding edge maybe?).

I also fixed an issue where it does not work after running once. `ln -s /usr/src/mediawiki/* .` will fail because the links already exist, causing the image to fail to start up because of `set -e`. I have merely changed it to `ln -sf` so it will overwrite existing links.

I have also fixed an issue where no links from `$MEDIAWIKI_SHARED` are set because the files in `/var/www/html` already exist from the previously mentioned link statement.

If you'd like me to break up this into different pull requests, please let me know. If this isn't appropriate for master, consider putting this or similar changes on a `1.27` branch and releasing it.